### PR TITLE
Update Gestione Errore 2502 e 2503.md

### DIFF
--- a/Risoluzione Errori/Gestione Errore 2502 e 2503/Gestione Errore 2502 e 2503.md
+++ b/Risoluzione Errori/Gestione Errore 2502 e 2503/Gestione Errore 2502 e 2503.md
@@ -2,101 +2,155 @@
 
 ## Introduzione
 
-Gli errori **2502** e **2503** in Windows si verificano durante l'installazione o disinstallazione di programmi e 
-sono comunemente legati a problemi di permessi di accesso. In Windows 11, questo tipo di errore può essere causato da conflitti 
-con i privilegi utente, una configurazione errata di Windows Installer o l'intervento di software di terze parti che gestisce i permessi.
+Gli errori **2502** e **2503** in Windows si verificano durante l'installazione o disinstallazione di programmi e sono comunemente legati a problemi di permessi di accesso. In Windows 11, questo tipo di errore può essere causato da conflitti con i privilegi utente, una configurazione errata di Windows Installer o l'intervento di software di terze parti che gestisce i permessi.
 
-Questa guida descrive i passaggi per risolvere gli errori 2502 e 2503 in modo che tu possa installare o disinstallare correttamente 
-i software, anche se si verificano questi errori.
+Questa guida descrive i passaggi per risolvere gli errori 2502 e 2503 in modo che tu possa installare o disinstallare correttamente i software, anche se si verificano questi errori.
 
-## Soluzioni per installare o disinstallare nonostante gli errori
+-----
 
-### 1. Installare un eseguibile di installazione `.msi`
+## 🛠 La Soluzione Definitiva: Correggere i Permessi alla Radice
 
-Se stai cercando di installare un file `.msi` e ricevi l'errore 2502 o 2503, puoi usare il comando `msiexec`, che è l'installer predefinito di Windows. 
-Questo metodo potrebbe bypassare eventuali problemi con l'installer predefinito:
+La causa più comune e la soluzione più efficace per gli errori 2502/2503 risiede spesso in permessi insufficienti per i processi di sistema e utente che accedono alle **cartelle temporanee di Windows**. Questo accade perché Windows Installer ha bisogno di scrivere e leggere file in queste posizioni per operare correttamente.
+
+**L'esperienza diretta ha dimostrato che la chiave per risolvere questi errori su Windows 11 è assicurarsi che i gruppi `TrustedInstaller` e `Users`, oltre a `SYSTEM` e `Administrators`, abbiano il "Controllo completo" su entrambe le cartelle temporanee del sistema.**
+
+**Ecco come ripristinare i permessi corretti:**
+
+1.  **Individua le Cartelle Temporanee:**
+
+      * Premi `Win + R` per aprire "Esegui".
+      * Digita `%TEMP%` e premi `Invio`. Si aprirà la cartella temporanea del tuo profilo utente (es. `C:\Users\<IlTuoNomeUtente>\AppData\Local\Temp`).
+      * Ripeti l'operazione, digitando questa volta `%WINDIR%\Temp` e premi `Invio`. Si aprirà la cartella temporanea di sistema (es. `C:\Windows\Temp`).
+
+2.  **Modifica i Permessi di Sicurezza (per *entrambe* le cartelle):**
+
+      * Fai clic destro su uno spazio vuoto all'interno della cartella (non su un file o una sottocartella) e seleziona **Proprietà**.
+      * Vai alla scheda **Sicurezza**.
+      * Clicca sul pulsante **Modifica...** per cambiare i permessi.
+
+3.  **Configura il "Controllo Completo" per i Gruppi Essenziali:**
+
+      * Nella finestra "Autorizzazioni per [Nome Cartella]", assicurati che i seguenti utenti/gruppi siano presenti e abbiano la casella **"Controllo completo"** spuntata sotto la colonna "Consenti":
+          * **`SYSTEM`**: Fondamentale per i servizi di sistema.
+          * **`Administrators`** (o "Amministratori"): Per gli utenti con privilegi amministrativi.
+          * **`Users`** (o "Utenti") o il tuo **nome utente specifico**: **Questo è cruciale.** Molte parti dei processi di installazione possono operare sotto questo contesto e richiedono pieni permessi di lettura/scrittura.
+          * **`TrustedInstaller`**: **Altrettanto cruciale.** `TrustedInstaller` è il proprietario di molti file di sistema ed è indispensabile per le operazioni di installazione/disinstallazione che modificano il sistema.
+      * **Se un gruppo non è presente:** Clicca su "Aggiungi...", digita il nome del gruppo (es. `TrustedInstaller`, `Users`, `SYSTEM`), clicca "Controlla nomi" e poi "OK". Una volta aggiunto, selezionalo e spunta "Controllo completo".
+      * Assicurati che "Controllo completo" sia spuntato per tutti i gruppi sopra menzionati.
+      * Clicca **Applica** e poi **OK** su tutte le finestre di dialogo aperte.
+      * **Ripeti tutti questi passaggi per l'altra cartella temporanea (`%WINDIR%\Temp`).**
+
+4.  **Riavvia il Computer:**
+
+      * È essenziale riavviare il PC per assicurarsi che tutte le modifiche ai permessi siano applicate correttamente e che i servizi vengano riavviati con le nuove configurazioni di sicurezza.
+
+Dopo aver eseguito questi passaggi, riprova l'installazione o disinstallazione che in precedenza ti dava errore. Nella maggior parte dei casi, questo risolverà definitivamente il problema degli errori 2502 e 2503.
+
+-----
+
+## Soluzioni Rapide e Workaround (nel caso la soluzione principale non bastasse)
+
+Se la correzione dei permessi non dovesse essere sufficiente o se necessiti di una soluzione immediata per completare un'installazione/disinstallazione, puoi utilizzare questi metodi.
+
+### 1\. Installare un eseguibile di installazione `.msi` tramite `msiexec`
+
+Se stai cercando di installare un file `.msi` e ricevi l'errore 2502 o 2503, puoi usare il comando `msiexec`, che è l'installer predefinito di Windows. Questo metodo può bypassare eventuali problemi con l'interfaccia grafica dell'installer:
 
 ```bash
 msiexec /i "C:\Users\YourUser\Desktop\BlueJ-windows-541.msi"
 ```
 
-Sostituisci il percorso del file `.msi` con il percorso effettivo del tuo programma da installare.
+Sostituisci il percorso del file `.msi` con il percorso effettivo del tuo programma da installare. Assicurati di eseguire il Prompt dei comandi **come amministratore** prima di digitare il comando.
 
-### 2. Installare un eseguibile di installazione `.exe` in modalità amministratore
+### 2\. Installare un eseguibile di installazione `.exe` in modalità amministratore
 
-Se stai cercando di installare un file `.exe` e ottieni gli errori, prova a eseguire il file come amministratore. Segui questi passaggi:
+Se stai cercando di installare un file `.exe` e ottieni gli errori, la prima cosa da provare è eseguire il file come amministratore. Segui questi passaggi:
 
-1. **Clic destro** sul file `.exe`.
-2. Seleziona **Esegui come amministratore**.
+1.  **Clic destro** sul file `.exe`.
+2.  Seleziona **Esegui come amministratore**.
 
 Se l'installazione fallisce comunque, prosegui con le soluzioni di disinstallazione qui sotto.
 
-### 3. Disinstallare un programma che causa errori 2502 e 2503
+### 3\. Disinstallare un programma che causa errori 2502 e 2503
 
-Se non riesci a disinstallare un programma attraverso il pannello di controllo e ottieni l'errore, prova il seguente metodo.
+Se non riesci a disinstallare un programma attraverso il Pannello di controllo e ottieni l'errore, prova il seguente metodo.
 
-#### Passo 1: Tentare di disinstallare dal pannello di controllo
+#### Passo 1: Tentare di disinstallare dal Pannello di controllo
 
 Prova a disinstallare il programma come fai normalmente:
 
-- Vai su **Pannello di controllo** > **Programmi** > **Programmi e funzionalità**.
-- Seleziona il programma che desideri disinstallare e clicca su **Disinstalla**.
+  * Vai su **Pannello di controllo** \> **Programmi** \> **Programmi e funzionalità**.
+  * Seleziona il programma che desideri disinstallare e clicca su **Disinstalla**.
 
 Se ottieni ancora l'errore, passa al passo 2.
 
 #### Passo 2: Utilizzare il comando `wmic` da CMD Amministratore
 
-Se non riesci a disinstallare il programma tramite il pannello di controllo, prova a farlo usando il comando `wmic` in modalità amministratore. 
-In Windows 11, potresti riscontrare che questo metodo funziona anche quando i permessi di amministrazione sono limitati da altre applicazioni.
+Se non riesci a disinstallare il programma tramite il Pannello di controllo, prova a farlo usando il comando `wmic` in modalità amministratore. In Windows 11, potresti riscontrare che questo metodo funziona anche quando i permessi di amministrazione sono limitati da altre applicazioni.
 
-1. Apri **CMD** come amministratore:
-   - Premi **Win + X** e seleziona **Prompt dei comandi (Amministratore)** o **Windows PowerShell (Amministratore)**.
-2. Una volta aperto il prompt, digita il seguente comando per ottenere una lista delle applicazioni installate:
+1.  Apri **CMD** come amministratore:
 
-   ```bash
-   wmic product get name
-   ```
+      * Premi `Win + X` e seleziona **Prompt dei comandi (Amministratore)** o **Windows PowerShell (Amministratore)**.
 
-   Questo comando ti mostrerà tutte le applicazioni installate nel sistema, e il loro **alias**.
+2.  Una volta aperto il prompt, digita il seguente comando per ottenere una lista delle applicazioni installate:
 
-3. Trova il nome del programma che desideri disinstallare nella lista, quindi digita il seguente comando, sostituendo `"NomeApplicazione"` 
-con il nome esatto del programma:
+    ```bash
+    wmic product get name
+    ```
 
-   ```bash
-   wmic product where name="NomeApplicazione" call uninstall
-   ```
+    Questo comando ti mostrerà tutte le applicazioni installate nel sistema e il loro **alias**.
 
-   Questo comando dovrebbe disinstallare l'applicazione direttamente, bypassando gli errori 2502 e 2503.
+3.  Trova il nome del programma che desideri disinstallare nella lista, quindi digita il seguente comando, sostituendo `"NomeApplicazione"` con il nome esatto del programma:
 
-## Ulteriori Soluzioni e Considerazioni
+    ```bash
+    wmic product where name="NomeApplicazione" call uninstall
+    ```
 
-Se nessuna delle soluzioni sopra funziona, potrebbe esserci un problema più complesso legato a Windows Installer o alla configurazione dei permessi utente. 
-In alcuni casi, gli errori 2502 e 2503 possono essere causati da un file di sistema danneggiato o da conflitti con altre applicazioni di sicurezza.
+    Questo comando dovrebbe disinstallare l'applicazione direttamente, bypassando gli errori 2502 e 2503.
 
-### Eseguire una riparazione di Windows Installer
+-----
 
-Se il problema persiste, potresti provare a riparare l'installazione di Windows Installer. Puoi farlo utilizzando il comando `sfc` (System File Checker) o `DISM` 
-per ripristinare i file di sistema danneggiati:
+## Ulteriori Soluzioni per Problemi Persistenti
 
-1. **Apri il Prompt dei comandi come amministratore**.
-2. Esegui il comando `sfc` per cercare e riparare file di sistema danneggiati:
+Se anche dopo aver tentato la soluzione definitiva e i workaround gli errori persistono, la causa potrebbe essere più profonda, legata a file di sistema danneggiati o a un problema con il servizio Windows Installer stesso.
 
-   ```bash
-   sfc /scannow
-   ```
+### Ripristinare i File di Sistema Corrotti (SFC e DISM)
 
-3. Se il problema persiste, usa `DISM` per ripristinare i componenti di Windows:
+Questi comandi sono utili per scansionare e riparare l'integrità dei file di sistema di Windows.
 
-   ```bash
-   DISM /Online /Cleanup-Image /RestoreHealth
-   ```
+1.  **Apri il Prompt dei comandi come amministratore**.
 
-Questi comandi aiuteranno a risolvere eventuali corruzioni nei file di sistema che potrebbero essere la causa dell'errore.
+2.  Esegui il comando **System File Checker (SFC)** per cercare e riparare file di sistema danneggiati:
+
+    ```bash
+    sfc /scannow
+    ```
+
+3.  Se il problema persiste, usa **Deployment Image Servicing and Management (DISM)** per ripristinare i componenti di Windows:
+
+    ```bash
+    DISM /Online /Cleanup-Image /RestoreHealth
+    ```
+
+Questi comandi possono aiutare a risolvere eventuali corruzioni nei file di sistema che potrebbero essere alla base dell'errore.
+
+-----
+
+## Come Sopravvivere con gli Errori (se nessuna soluzione funziona)
+
+Se, nonostante tutti i tentativi, gli errori 2502 e 2503 persistono e non riesci a trovare una soluzione permanente, puoi comunque "sopravvivere" gestendo le installazioni e disinstallazioni.
+
+  * **Affidati ai Metodi da Riga di Comando:** I comandi `msiexec /i` per l'installazione e `wmic product where name="NomeApplicazione" call uninstall` per la disinstallazione diventano i tuoi migliori amici. Spesso bypassano le restrizioni che impediscono alle interfacce grafiche di funzionare.
+  * **Utilizza lo Strumento di Risoluzione dei Problemi di Microsoft:** Scarica e tieni a portata di mano il "Microsoft Program Install and Uninstall Troubleshooter". È uno strumento diagnostico automatico che può risolvere problemi specifici quando gli altri metodi falliscono.
+  * **Software Portatile:** Per i nuovi programmi che intendi installare, cerca versioni "portable" (portatili). Questi programmi non richiedono un'installazione nel senso tradizionale del termine e possono essere eseguiti direttamente da una cartella, evitando completamente il servizio Windows Installer.
+  * **Valuta una Reinstallazione Pulita (Ultima Ratio):** Se gli errori sono troppo frequenti e ti impediscono di usare il sistema in modo efficace, e sospetti una corruzione profonda del sistema operativo (magari a seguito di ottimizzazioni aggressive passate), una reinstallazione pulita di Windows potrebbe essere l'unica soluzione definitiva. È drastica, ma garantisce un sistema pulito da zero.
+
+-----
 
 ### Considerazioni Finali
 
-Gli errori 2502 e 2503 sono spesso legati a problemi di permessi di amministrazione o a configurazioni di Windows Installer errate. 
-In Windows 11, la gestione dei permessi è più rigorosa, ma i metodi descritti dovrebbero aiutarti a superare questi problemi e a installare 
-o disinstallare i programmi con successo.
+Gli errori 2502 e 2503 sono spesso legati a problemi di permessi di amministrazione o a configurazioni di Windows Installer errate. In Windows 11, la gestione dei permessi è più rigorosa, ma i metodi descritti, in particolare la correzione dei permessi alle cartelle temporanee, dovrebbero aiutarti a superare questi problemi e a installare o disinstallare i programmi con successo.
 
 Ricorda di eseguire un backup o un punto di ripristino prima di fare modifiche significative al sistema, in modo da evitare eventuali problemi irreversibili.
+
+-----


### PR DESCRIPTION
Risolta la causa principale degli errori 2502 e 2503 su Windows 11

Prima: La guida offriva metodi per aggirare gli errori 2502 e 2503, non sempre efficaci.

Ora: Trovata la soluzione definitiva ai problemi di permessi, garantendo il "Controllo completo" a TrustedInstaller e Users nelle cartelle Temp.